### PR TITLE
Add n to feedkeys options to avoid remapping i and w

### DIFF
--- a/lua/coerce/conversion.lua
+++ b/lua/coerce/conversion.lua
@@ -89,7 +89,7 @@ end
 --@treturn Region The selected region.
 M.select_current_word = function()
 	local operator_m = require("coerce.operator")
-	return operator_m.operator("x", "iw")
+	return operator_m.operator("xn", "iw")
 end
 
 --- Selects with the user provided motion.

--- a/tests/coerce_spec.lua
+++ b/tests/coerce_spec.lua
@@ -64,4 +64,16 @@ describe("coerce", function()
 			notification
 		)
 	end)
+
+	it("coerces current word even with conflicting keymaps", function()
+		local buf = test_helpers.create_buf({ "myCase" })
+		vim.keymap.set("o", "i", '<cmd>echo "Pressed i"<cr>')
+		vim.keymap.set("o", "w", '<cmd>echo "Pressed w"<cr>')
+		c.setup({})
+		-- `cru` runs upper case coercion
+		test_helpers.execute_keys("cru", "x")
+
+		local lines = vim.api.nvim_buf_get_lines(buf, 0, 1, true)
+		assert.are.same({ "MY_CASE" }, lines)
+	end)
 end)


### PR DESCRIPTION
If someone has mapped `i` or `w` to something else, this plugin doesn't work for them, that's why we need to avoid remapping in `nvim_feedkeys`