### PR TITLE
feat: textDocument/rename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ to change case of the current keyword, Coerce is simpler.
 | Current keyword coerce             | ✅     | ❌                     | ✅                 |
 | Visual selection                   | ✅     | ✅                     | ❌                 |
 | Motion selection                   | ✅     | ✅                     | ❌                 |
-| LSP rename                         | ❌     | ✅                     | ❌                 |
+| LSP rename                         | ✅     | ✅                     | ❌                 |
 | Kebab case                         | ✅     | ✅                     | ✅                 |
 | [Numeronym] “case”                 | ✅     | ❌                     | ❌                 |
 | Custom case support                | ✅     | ❌                     | ❌                 |


### PR DESCRIPTION
It seems to be a long-awaited missing feature. 
1. Should it be configurable?
2. Should it be disabled in visual mode?